### PR TITLE
Rebased. Allowed implicit relative references for Python > 3.3 

### DIFF
--- a/scripts/02_bert_ner/main.py
+++ b/scripts/02_bert_ner/main.py
@@ -1,6 +1,14 @@
 
+import sys
 from os import getenv, environ
-from os.path import exists, join, expanduser
+from os.path import dirname, realpath, exists, join
+
+# Starting from Python 3.3, implicit relative references are allowed no more
+# explanation - https://codeolives.com/2020/01/10/python-reference-module-in-parent-directory/
+currentdir = dirname(realpath(__file__))
+rootdir = dirname(dirname(currentdir))
+sys.path.append(rootdir)
+
 from random import seed, sample, randint, uniform
 from subprocess import run
 
@@ -57,7 +65,6 @@ from slovnet.mask import (
     split_masked,
     pad_masked
 )
-
 
 DATA_DIR = 'data'
 MODEL_DIR = 'model'

--- a/scripts/05_ner/main.py
+++ b/scripts/05_ner/main.py
@@ -1,6 +1,16 @@
 
+
+
+import sys
 from os import getenv, environ
-from os.path import exists, join, expanduser
+from os.path import dirname, realpath, exists, join
+
+# Starting from Python 3.3, implicit relative references are allowed no more
+# explanation - https://codeolives.com/2020/01/10/python-reference-module-in-parent-directory/
+currentdir = dirname(realpath(__file__))
+rootdir = dirname(dirname(currentdir))
+sys.path.append(rootdir)
+
 from random import seed, shuffle, sample, randint, uniform
 from itertools import islice as head
 from subprocess import run


### PR DESCRIPTION
By adding root directory into the sys path environment variable.

The idea is to have the ability to run the .py scripts from the repo (**./slovnet/slovnet/..**) rather than from preinstalled pip module **slovnet**.

It is allowing to debug the invocation chain and quite convenient for those who trying to familiarize themselves with the module architecture